### PR TITLE
Support for rotating log files by date

### DIFF
--- a/source/confogl_system/scripting/confogl_system/includes/logging.sp
+++ b/source/confogl_system/scripting/confogl_system/includes/logging.sp
@@ -72,10 +72,7 @@ Logger CreateBaseFileLoggerOrFailed(const char[] name)
 
 	if (!log)
 	{
-		char sChatFilePath[PLATFORM_MAX_PATH], sDate[32];
-		FormatTime(sDate, sizeof(sDate), "%d-%m-%y", -1);
-		BuildPath(Path_SM, sChatFilePath, sizeof(sChatFilePath), "" ... LOGFILE_PATH... "log-[%s]-port-[%i].log", sDate, FindConVar("hostport").IntValue);
-		log = BasicFileSink.CreateLogger(name, sChatFilePath);
+		log = DailyFileSink.CreateLogger(name, LOGFILE_PATH ... "log-[%d-%m-%y].log", _, _, _, _, DailyFilePortCalculator);
 		if (!log) SetFailState("[Confogl] Failed to create logger.");
 	}
 
@@ -85,4 +82,34 @@ Logger CreateBaseFileLoggerOrFailed(const char[] name)
 static void OnDebugChange(ConVar hConVar, const char[] sOldValue, const char[] sNewValue)
 {
 	hConVar.BoolValue ? g_hLogger.SetLevel(LogLevel_Debug) : g_hLogger.SetLevel(LogLevel_Info);
+}
+
+void DailyFilePortCalculator(char[] filename, int maxlen, int sec)
+{
+	char buffer[PLATFORM_MAX_PATH];
+	int extIndex = FindCharInString(filename, '.', true);
+
+	// no valid extension found
+	if (extIndex <= 0 || extIndex == strlen(filename) - 1)
+	{
+		FormatEx(buffer, sizeof(buffer), "%s-port[%d]", filename, FindConVar("hostport").IntValue);
+		FormatTime(filename, maxlen, buffer, sec);
+		return;
+	}
+
+	// treat cases like "/etc/rc.d/somelogfile or "/abc/.hiddenfile"
+	int folderIndex = FindCharInString(filename, '/', true);
+	if (folderIndex == -1)
+		folderIndex = FindCharInString(filename, '\\', true);
+
+	if (folderIndex == -1 || folderIndex >= extIndex - 1)
+	{
+		FormatEx(buffer, sizeof(buffer), "%s-port[%d]", filename, FindConVar("hostport").IntValue);
+		FormatTime(filename, maxlen, buffer, sec);
+		return;
+	}
+
+	filename[extIndex] = '\0';
+	FormatEx(buffer, sizeof(buffer), "%s-port[%d].%s", filename, FindConVar("hostport").IntValue, filename[extIndex + 1]);
+	FormatTime(filename, maxlen, buffer, sec);
 }

--- a/source/savechat/scripting/savechat.sp
+++ b/source/savechat/scripting/savechat.sp
@@ -212,16 +212,43 @@ void GetTeamNameEx(int team, char[] szName, int iMaxLen)
 
 Logger CreateLoggerOrFailed(const char[] name)
 {
-	char sChatFilePath[PLATFORM_MAX_PATH], sDate[32];
 	Logger logger = Logger.Get(name);
 
 	if (!logger)	// if not exist, create new one.
 	{
-		FormatTime(sDate, sizeof(sDate), "%d-%m-%y", -1);
-		BuildPath(Path_SM, sChatFilePath, sizeof(sChatFilePath), "/logs/savechat/savechat[%s]-port[%i].log", sDate, g_hHostport.IntValue);
-		logger = BasicFileSink.CreateLogger(LOGGER_NAME, sChatFilePath);
+		logger = DailyFileSink.CreateLogger(LOGGER_NAME, "/logs/savechat/savechat[%d-%m-%y].log", _, _, _, _, DailyFilePortCalculator);
 		if (!logger) SetFailState("Failed to create log file.");
 	}
 
 	return logger;
+}
+
+void DailyFilePortCalculator(char[] filename, int maxlen, int sec)
+{
+	char buffer[PLATFORM_MAX_PATH];
+	int extIndex = FindCharInString(filename, '.', true);
+
+	// no valid extension found
+	if (extIndex <= 0 || extIndex == strlen(filename) - 1)
+	{
+		FormatEx(buffer, sizeof(buffer), "%s-port[%d]", filename, g_hHostport.IntValue);
+		FormatTime(filename, maxlen, buffer, sec);
+		return;
+	}
+
+	// treat cases like "/etc/rc.d/somelogfile or "/abc/.hiddenfile"
+	int folderIndex = FindCharInString(filename, '/', true);
+	if (folderIndex == -1)
+		folderIndex = FindCharInString(filename, '\\', true);
+
+	if (folderIndex == -1 || folderIndex >= extIndex - 1)
+	{
+		FormatEx(buffer, sizeof(buffer), "%s-port[%d]", filename, g_hHostport.IntValue);
+		FormatTime(filename, maxlen, buffer, sec);
+		return;
+	}
+
+	filename[extIndex] = '\0';
+	FormatEx(buffer, sizeof(buffer), "%s-port[%d].%s", filename, g_hHostport.IntValue, filename[extIndex + 1]);
+	FormatTime(filename, maxlen, buffer, sec);
 }


### PR DESCRIPTION
当前的方案除非重载插件以重建 Logger，否则不会按日期迭代日志文件，日志消息总是写入同一个日志文件。

新方案借助 log4sp `v1.8.0` 的新特性解决了这个问题，不影响自定义日期格式。

由于缺乏相关环境，仅测试了 savechat 创建的日志文件名。

如果不需要按日期迭代日志，或只需要创建时的日期而不需要迭代则可以关闭 pr。