### PR TITLE
Fix log file name may be calculated incorrectly

### DIFF
--- a/source/confogl_system/scripting/confogl_system/includes/logging.sp
+++ b/source/confogl_system/scripting/confogl_system/includes/logging.sp
@@ -104,7 +104,7 @@ void DailyFilePortCalculator(char[] filename, int maxlen, int sec)
 	if (folderIndex == -1)
 		folderIndex = FindCharInString(filename, '\\', true);
 
-	if (folderIndex == -1 || folderIndex >= extIndex - 1)
+	if (folderIndex != -1 && folderIndex >= extIndex - 1)
 	{
 		FormatEx(buffer, sizeof(buffer), "%s-port[%d]", filename, FindConVar("hostport").IntValue);
 		FormatTime(filename, maxlen, buffer, sec);

--- a/source/savechat/scripting/savechat.sp
+++ b/source/savechat/scripting/savechat.sp
@@ -243,7 +243,7 @@ void DailyFilePortCalculator(char[] filename, int maxlen, int sec)
 	if (folderIndex == -1)
 		folderIndex = FindCharInString(filename, '\\', true);
 
-	if (folderIndex == -1 || folderIndex >= extIndex - 1)
+	if (folderIndex != -1 && folderIndex >= extIndex - 1)
 	{
 		FormatEx(buffer, sizeof(buffer), "%s-port[%d]", filename, g_hHostport.IntValue);
 		FormatTime(filename, maxlen, buffer, sec);


### PR DESCRIPTION
Introduced By #25 

Sorry, my bad.

test case:

```sourcepawn
DailyFileSink.CreateLogger(LOGGER_NAME, "savechat.log", _, _, _, _, DailyFilePortCalculator);
```

Expected: 

```
"savechat-port[27015].log"
```

Output: 
```
"savechat.log-port[27015]"
```